### PR TITLE
Respect autoPublish property

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "prepack": "npm install && tsc",
     "publishall": "npm install && tsc && node dist/index.js",
     "publishall:auto": "npm install && tsc && node dist/index.js auto",
-    "specialname": "npm install && tsc && node dist/index.js",
     "unpublishall": "npm install && tsc && node dist/index.js unpublish"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "tsc && nyc mocha ./dist/test/*.js --reporter mocha-junit-reporter",
     "prepack": "npm install && tsc",
     "publishall": "npm install && tsc && node dist/index.js",
+    "publishall:auto": "npm install && tsc && node dist/index.js auto",
     "specialname": "npm install && tsc && node dist/index.js",
     "unpublishall": "npm install && tsc && node dist/index.js unpublish"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const traverse = async (dir: string, action: Action, auto: boolean): Promise<voi
             const id = `${name}@${version}`
 
             if (auto && autoPublish !== true) {
-                console.log(`skipping ${id} because autoPublish property is set to false`)
+                console.log(`skipping ${id} because autoPublish property is set to false or is missing`)
                 continue;
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const traverse = async (dir: string, action: Action, auto: boolean): Promise<voi
             const id = `${name}@${version}`
 
             if (auto && autoPublish === true) {
-                console.log(`skipping ${id} because `)
+                console.log(`skipping ${id} because autoPublish property is set to true`)
                 continue;
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,17 @@ import decompress from "decompress"
 interface Package {
     readonly name: string
     readonly version: string
+    readonly autoPublish?: boolean
 }
 
 type Action = "publish"|"unpublish"
 
-const traverse = async (dir: string, action: Action): Promise<void> => {
+const traverse = async (dir: string, action: Action, auto: boolean): Promise<void> => {
     const files = fs.readdirSync(dir, { withFileTypes: true })
     for (const file of files) {
         const filePath = path.join(dir, file.name)
         if (file.isDirectory()) {
-            traverse(filePath, action)
+            traverse(filePath, action, auto)
         } else if (path.extname(file.name) === ".tgz") {
             const files = await decompress(
                 filePath,
@@ -24,8 +25,14 @@ const traverse = async (dir: string, action: Action): Promise<void> => {
                 }
             )
             const packageJson = files[0]
-            const { name, version } = JSON.parse(packageJson.data.toString()) as Package
+            const { name, version, autoPublish } = JSON.parse(packageJson.data.toString()) as Package
             const id = `${name}@${version}`
+
+            if (auto && autoPublish === true) {
+                console.log(`skipping ${id} because `)
+                continue;
+            }
+
             let viewNames: string = ""
             try {
                 viewNames = child_process.execSync(`npm view ${id} name`).toString()
@@ -40,7 +47,8 @@ const traverse = async (dir: string, action: Action): Promise<void> => {
                     const cmd = `npm publish "${fullPath}" --access=public`
                     console.log(`running: ${cmd}`)
                     try {
-                        child_process.execSync(cmd)
+                        console.log(`WHATIF: ${cmd}`)
+                        // child_process.execSync(cmd)
                         console.log(`${id} done.`)
                     } catch (e) {
                         process.exitCode = 1
@@ -53,7 +61,8 @@ const traverse = async (dir: string, action: Action): Promise<void> => {
                 if (exist) {
                     console.log(`unpublishing ${id} from ${filePath}`)
                     try {
-                        child_process.execSync(`npm unpublish ${id}`)
+                        console.log(`WHATIF: npm unpublish ${id}`)
+                        // child_process.execSync(`npm unpublish ${id}`)
                     } catch (e) {
                         process.exitCode = 1
                     }
@@ -68,5 +77,7 @@ const traverse = async (dir: string, action: Action): Promise<void> => {
 // console.log("@ts-common/publish is started")
 // const cwd = path.resolve("./")
 // console.log(`current folder: ${cwd}`)
-traverse("..", process.argv.indexOf("unpublish") >= 0 ? "unpublish" : "publish")
+const action = process.argv.indexOf("unpublish") >= 0 ? "unpublish" : "publish"
+const autoPublish = process.argv.indexOf("auto") >= 0
+traverse("..", action, autoPublish)
 // console.log("@ts-common/publish is done")

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,7 @@ const traverse = async (dir: string, action: Action, auto: boolean): Promise<voi
                     const cmd = `npm publish "${fullPath}" --access=public`
                     console.log(`running: ${cmd}`)
                     try {
-                        console.log(`WHATIF: ${cmd}`)
-                        // child_process.execSync(cmd)
+                        child_process.execSync(cmd)
                         console.log(`${id} done.`)
                     } catch (e) {
                         process.exitCode = 1
@@ -61,8 +60,7 @@ const traverse = async (dir: string, action: Action, auto: boolean): Promise<voi
                 if (exist) {
                     console.log(`unpublishing ${id} from ${filePath}`)
                     try {
-                        console.log(`WHATIF: npm unpublish ${id}`)
-                        // child_process.execSync(`npm unpublish ${id}`)
+                        child_process.execSync(`npm unpublish ${id}`)
                     } catch (e) {
                         process.exitCode = 1
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,8 @@ const traverse = async (dir: string, action: Action, auto: boolean): Promise<voi
             const { name, version, autoPublish } = JSON.parse(packageJson.data.toString()) as Package
             const id = `${name}@${version}`
 
-            if (auto && autoPublish === true) {
-                console.log(`skipping ${id} because autoPublish property is set to true`)
+            if (auto && autoPublish !== true) {
+                console.log(`skipping ${id} because autoPublish property is set to false`)
                 continue;
             }
 


### PR DESCRIPTION
Modify scripts to respect "autoPublish" property from package.json.
This is used in azure-sdk-for-js repository, all other projects that use this script will not be affected.